### PR TITLE
IndexOptimize Fix NORECOMPUTE before the RESAMPLE issue

### DIFF
--- a/IndexOptimize.sql
+++ b/IndexOptimize.sql
@@ -2239,16 +2239,16 @@ BEGIN
             SELECT 'SAMPLE ' + CAST(@CurrentStatisticsSample AS nvarchar) + ' PERCENT'
           END
 
-          IF @CurrentStatisticsResample = 'Y'
-          BEGIN
-            INSERT INTO @CurrentUpdateStatisticsWithClauseArguments (Argument)
-            SELECT 'RESAMPLE'
-          END
-
           IF @CurrentNoRecompute = 1
           BEGIN
             INSERT INTO @CurrentUpdateStatisticsWithClauseArguments (Argument)
             SELECT 'NORECOMPUTE'
+          END
+
+          IF @CurrentStatisticsResample = 'Y'
+          BEGIN
+            INSERT INTO @CurrentUpdateStatisticsWithClauseArguments (Argument)
+            SELECT 'RESAMPLE'
           END
 
           IF EXISTS (SELECT * FROM @CurrentUpdateStatisticsWithClauseArguments)


### PR DESCRIPTION
Copy of #611 as that isn't getting merged into the master fork.

>Changed order of insert to move NORECOMPUTE before the RESAMPLE.
Should resolve Issue https://github.com/olahallengren/sql-server-maintenance-solution/issues/106 and Issue https://github.com/olahallengren/sql-server-maintenance-solution/issues/285